### PR TITLE
Fixes #21 - GH may add trailing newline

### DIFF
--- a/__docs/phpdoc/en/hack/traits.xml
+++ b/__docs/phpdoc/en/hack/traits.xml
@@ -137,10 +137,10 @@ No errors!
     <informalexample>
       <programlisting role="php">
 <![CDATA[
-&lt;?hh
+<?hh
 
 interface Bar {
-public function babs(Vector&lt;int&gt; $vec): int;
+public function babs(Vector<int> $vec): int;
 public function get(): int;
 }
 


### PR DESCRIPTION
Fixed a couple of '&amp;lt;' and '&amp;gt;' entries within the CDATA of the "traits can implement interfaces" section.  Hopefully this will enable syntax highlighting of that section.
