### PR TITLE
Clarify that else if does not require curly braces

### DIFF
--- a/__docs/phpdoc/en/hack/unsupported.xml
+++ b/__docs/phpdoc/en/hack/unsupported.xml
@@ -26,7 +26,7 @@
       </listitem>
       <listitem>
         <para>
-          <literal>if/then/else</literal> without <literal>{}</literal>
+          <literal>if/else</literal> statements without <literal>{}</literal>. <literal>else if</literal> is allowed (i.e. <literal>if (...) { ... } else if (...) { ... } else { ... }</literal> is ok).
         </para>
       </listitem>
       <listitem>


### PR DESCRIPTION
This question came up a few times, so I think it's worth clarifying.
