### PR TITLE
Rename `dispatch` function to `fetchDispatch` to match the callsite 

### DIFF
--- a/__docs/phpdoc/en/hack/async.xml
+++ b/__docs/phpdoc/en/hack/async.xml
@@ -111,7 +111,7 @@ class Batcher {
     return $results[$id];
   }
 
-  private static async function dispatch(): Awaitable<array<int, int>> {
+  private static async function fetchDispatch(): Awaitable<array<int, int>> {
     await RescheduleWaitHandle::create(0, 0);
     $ids = self::$ids;
     self::$ids = null;


### PR DESCRIPTION
Easy fix for https://github.com/hhvm/hack-hhvm-docs/issues/107

The callsite on line 108 was calling `fetchDispatch()` but we only declared `dispatch()`
