### PR TITLE
Give search suggestion some space

### DIFF
--- a/styles/theme-base.css
+++ b/styles/theme-base.css
@@ -1089,7 +1089,7 @@ fieldset {
     border: none;
     color: white;
     display: block;
-    padding: 0.3em;
+    padding: 1.3em 0em 1.3em 0.3em;
     background: rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
The CSS for the top-right typeahead isn't great. Not sure if the fix should be in the base theme or we should branch out in a different CSS file. Thoughts?

fixes #103

Before:
![screen shot 2014-03-27 at 4 47 17 pm](https://cloud.githubusercontent.com/assets/821842/2544952/364f3a68-b60a-11e3-825f-ef783a14777e.png)

After:
![screen shot 2014-03-27 at 4 47 03 pm](https://cloud.githubusercontent.com/assets/821842/2544953/36532eb6-b60a-11e3-8a27-277eebbdcea1.png)
