### PR TITLE
Update unsupported features

### DIFF
--- a/__docs/phpdoc/en/hack/unsupported.xml
+++ b/__docs/phpdoc/en/hack/unsupported.xml
@@ -61,11 +61,6 @@
       </listitem>
       <listitem>
         <para>
-          Using PHP reserved keywords, constants, classes, <literal>parent</literal>, <literal>true</literal>, <literal>false </literal> as function, names or variable names. Trying to do so will result in a Hack syntax error.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           Globals (e.g., <literal>global $x;</literal>)
         </para>
       </listitem>


### PR DESCRIPTION
Using PHP reserved keywords in function or variable names is no longer unsupported - closes https://github.com/hhvm/hack-hhvm-docs/issues/139
