### PR TITLE
Rewrote the last fun example

### DIFF
--- a/__docs/phpdoc/en/hack/otherrulesandfeatures.xml
+++ b/__docs/phpdoc/en/hack/otherrulesandfeatures.xml
@@ -588,15 +588,37 @@ Invalid argument
         <programlisting role="php">
 <![CDATA[
 <?hh
-function foo(): void {}
+
+function foo(string $var): void {
+  echo $var."\n";
+}
 
 function main(): void {
-  $func = fun('foo');
-  $str = "foo";
-  // $wontwork = func($str);
+  $name='foo';
+  $func1 = fun($name); // the Hack type checker would balk
+  $func1('bar');
+
+  $func2 = fun('foo'); // This is correct
+  $func2('biz');
+
+  // func2('baz'); //this will not work
 }
+
+main();
 ]]>
         </programlisting>
+		&example.outputs;
+		<screen>
+<![CDATA[
+/source/fun.hh:9:18,22: The argument to fun() must be a single-quoted, constant literal string representing a valid function name.
+]]>
+		</screen>
+		<screen>
+<![CDATA[
+bar
+biz
+]]>
+		 </screen>
       </informalexample>
     </para>
     <para>


### PR DESCRIPTION
The line above the example says: 

> It is important to note that the argument to function fun() must be a single-quoted, constant literal string representing a valid function name. For example:

I did not understand the example at all... Nobody expected `func($str)` to work and it has nothing to do with the line above. `$func($str)` will work, but I believe this was not the purpose of the example.

I changed the example to illustrate a situation where we are not using a "constant literal string". I think this was the intention of the example. 
