### PR TITLE
Fixed typo

### DIFF
--- a/__docs/phpdoc/en/hack/predefined/keyedtraversabletktv.xml
+++ b/__docs/phpdoc/en/hack/predefined/keyedtraversabletktv.xml
@@ -12,7 +12,7 @@
   <section xml:id="hack.keyedtraversabletktv.intro">
    &reftitle.intro;
    <para>
-    Interface to detect if a class is traversable using &foreach;, of the form <literal>foreach($c => $k as $v)</literal>.
+    Interface to detect if a class is traversable using &foreach;, of the form <literal>foreach($c as $k => $v)</literal>.
    </para>
    <para>
     Abstract base interface that cannot be implemented alone. Instead it must


### PR DESCRIPTION
The foreach does never have the form `foreach($c => $k as $v)`. It should be  `foreach($c as $k => $v)`.
