### PR TITLE
Fix ASCII dir structure

### DIFF
--- a/__docs/phpdoc/en/install/hack/bootstrapping.xml
+++ b/__docs/phpdoc/en/install/hack/bootstrapping.xml
@@ -12,22 +12,21 @@
     <para>Now, run <literal>hh_client</literal>. This will start up the typechecking daemon, wait for it to finish checking the current directory tree, and report any errors that it found. Since your code is at this point likely all PHP and not Hack code, it should report <literal>No errors</literal>.</para>
     <note>
       <para>
-        When you run <literal>hh_client</literal>, it looks in the current directory for the <literal>.hhconfig</literal> file. If <literal>.hhconfig</literal> is not found in the current directory, the directory tree will be traversed looking for that file until it finds one (or not).
+        When you run <literal>hh_client</literal>, it looks in the current directory for the <literal>.hhconfig</literal> file. If <literal>.hhconfig</literal> is not found in the current directory, the directory tree will be traversed upward looking for that file until it finds one (or not).
         <informalexample>
           <programlisting role="bash">
 <![CDATA[
-/projects
---/project-1
---.hhconfig
---/app
-
---/project-2
---/app
---.hhconfig
+projects/
+├── project-1/
+│   └── app/
+│       └── .hhconfig
+├── project-2/
+│   └── app/
+└── .hhconfig
 ]]>
           </programlisting>
           <para>
-            If you run <literal>hh_client</literal> in <literal>project-2</literal>, you actually run <literal>hh_client</literal> for the whole <literal>projects</literal> directory, potentially exposing errors in <literal>project-1</literal> instead. Also, if you run <literal>hh_client</literal> in <literal>project-1/app</literal> and there is an <literal>.hhconfig</literal> file there as well, the type checker will only check that directory, potentially ignoring other errors in <literal>project-1</literal>, outside the <literal>app</literal> directory.
+            If you run <literal>hh_client</literal> in <literal>project-2</literal>, it will find the <literal>projects/.hhconfig</literal>, meaning you actually run <literal>hh_client</literal> for the whole <literal>projects</literal> directory, potentially exposing errors in <literal>project-1</literal> too. Also, if you run <literal>hh_client</literal> in <literal>project-1/app</literal> and there is an <literal>.hhconfig</literal> file there as well, the type checker will only check that directory, potentially ignoring other errors in <literal>project-1</literal>, outside the <literal>app</literal> directory.
           </para>
         </informalexample>
       </para>


### PR DESCRIPTION
Uses `tree -aF --dirsfirst` to create a nicer ASCII display, and actually correctly shows the directory structure.

Also, clarifies the description.
