### PR TITLE
Added type and newtype to reserved keywords

### DIFF
--- a/__docs/phpdoc/en/appendices/reserved.xml
+++ b/__docs/phpdoc/en/appendices/reserved.xml
@@ -49,8 +49,10 @@
         <link linkend="hack.otherrulesandfeatures.numberhandling">num</link>
        </entry>
        <entry>
+        <link linkend="hack.typealiasing.typealiasing">type</link>
        </entry>
        <entry>
+        <link linkend="hack.typealiasing.opaquetypealiasing">newtype</link>
        </entry>
        <entry>
        </entry>


### PR DESCRIPTION
I've added type and newtype to the list of reserved Hack keywords with links to the typealiasing and opaquetypealiasing pages where they are described.
