### PR TITLE
Fix "not supported" for variables

### DIFF
--- a/__docs/phd/phpdotnet/phd/Package/PHP/XHTML.php
+++ b/__docs/phd/phpdotnet/phd/Package/PHP/XHTML.php
@@ -740,7 +740,9 @@ abstract class Package_PHP_XHTML extends Package_Generic_XHTML {
 
     // For HHVM
     private function check_hhvm_function_support($function_or_method_name) {
-      if (strpos($function_or_method_name, "::") === false) {
+      if ($function_or_method_name[0] == '$') {
+        return true;
+      } else if (strpos($function_or_method_name, "::") === false) {
         return function_exists($function_or_method_name);
       } else {
         // If we have a ::, it is a class name


### PR DESCRIPTION
We support all global variables, so just return true for them

Checking if they are set doesn't work with variable variables inside function
http://3v4l.org/WcL7P

Proof that we support everything:
http://3v4l.org/sUIPi#vhhvm-330

Undefined for
- $php_errormsg
- $http_response_header

because of 3v4l.org (php doesn't find them either)

We support them in reality

Fixes #396
