### PR TITLE
Remove references to MySQL from MCRouter documentation

### DIFF
--- a/__docs/phpdoc/en/hackref/mcrouter/book.xml
+++ b/__docs/phpdoc/en/hackref/mcrouter/book.xml
@@ -19,7 +19,7 @@
     Mcrouter supports typical memcache protocol commands like get, set, delete, etc. and specific commands to access stats, version and so on.
   </para>
   <para>
-   There are 3 classes associated with async MySQL:
+   There are 3 classes associated with MCRouter:
    <itemizedlist>
      <listitem><para><link linkend="class.hack.mcrouter.mcrouter">MCRouter</link></para></listitem>
      <listitem><para><link linkend="class.hack.mcrouter.mcrouterexception">MCRouterException</link></para></listitem>


### PR DESCRIPTION
This may have been due to copy paste from somewhere. I refer to the classes as related to MCRouter instead of async Memcached because that seems to be the name used throughout the rest of the documentation.