### PR TITLE
Update xhp.xml to reflect new version of XHP-lib

### DIFF
--- a/__docs/phpdoc/en/install/xhp.xml
+++ b/__docs/phpdoc/en/install/xhp.xml
@@ -20,12 +20,9 @@ Fatal error: Class undefined: xhp_html in /
     You can find the XHP library in <link xlink:href="&url.xhp;">Github</link>. Add the following lines to your <literal>composer.json</literal> to install the library.
    <programlisting>
    "require": {
-     "facebook/xhp-lib": "dev-master"
+     "facebook/xhp-lib": "2.x"
    }
    </programlisting>
-  </para>
-  <para>
-    Finally, either (1) change the XHP files from <literal>&lt;?php</literal> to <literal>&lt;?hh // decl</literal> (since XHP class name is supported out of the box in Hack) or (2) set <literal>hhvm.enable_xhp=true</literal> in your <literal>.ini</literal> file or directly on the command line when running HHVM.
   </para>
 </chapter>
 


### PR DESCRIPTION
facebook/xhp-lib is now on version 2.x and is `<?hh` by default